### PR TITLE
Simplify client-side search feature

### DIFF
--- a/public/rainfall.js
+++ b/public/rainfall.js
@@ -10,12 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         listItems.forEach(function(article) {
 
-            var textContent = article.textContent.toLowerCase();
-            var hrefLinks = article.querySelectorAll('a[href]');
-            hrefLinks.forEach(function(link) {
-                textContent += link.getAttribute('href').toLowerCase();
-                textContent += ' ' + link.getAttribute('href').replace('_', '').replace('-', '').toLowerCase();
-            });
+            const textContent = article.textContent.toLocaleLowerCase();
 
             if (textContent.indexOf(searchValue) === -1) {
                 article.style.display = 'none';

--- a/public/rainfall.js
+++ b/public/rainfall.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     searchInput.addEventListener('keyup', function() {
         let listItems = document.querySelectorAll('#home ul li');
 
-        let searchValue = searchInput.value.toLowerCase();
+        let searchValue = searchInput.value.toLocaleLowerCase();
 
         listItems.forEach(function(article) {
 


### PR DESCRIPTION
The client-side search is great, but was doing too much. Firstly, with the current generation of the stations list, each `li` element can only have one `a` tag, so there's no reason to loop through a list of one element. Second, at this time, there's no information in the link's `href` field that isn't in the list item's `textContent`. Because of this, there's no use adding it to the text to search.

Removing these leaves a more simple search that accomplishes the same end result.